### PR TITLE
Added a safeguard for username when the owner is an unregistered user

### DIFF
--- a/src/questions.js
+++ b/src/questions.js
@@ -69,10 +69,7 @@ const prepare = (questions, type, options) => {
                 prepared = questions.map(question => {
                     // If this is an unregistered user, take the display_name value
                     // otherwise, take the username from the user's profile link
-                    let username = question.owner.display_name;
-                    if (question.owner.link !== undefined ) {
-                        username = question.owner.link.split('/')[question.owner.link.split('/').length-1];
-                    }
+                    let username = question.owner.hasOwnProperty("link") ? question.owner.link.split('/')[question.owner.link.split('/').length-1]: question.owner.display_name;
                     return {
                         activity: {
                             description: `__${question.title}__\n\nTags: ${question.tags.join(', ')}`,
@@ -117,7 +114,6 @@ const prepare = (questions, type, options) => {
                     return question.creation_date > oldestAllowable
                 })
             }
-
             resolve(prepared)
         } catch(error) {
             reject(error)

--- a/src/questions.js
+++ b/src/questions.js
@@ -67,6 +67,12 @@ const prepare = (questions, type, options) => {
 
             if(type == 'orbitActivity') {
                 prepared = questions.map(question => {
+                    // If this is an unregistered user, take the display_name value
+                    // otherwise, take the username from the user's profile link
+                    let username = question.owner.display_name;
+                    if (question.owner.link !== undefined ) {
+                        username = question.owner.link.split('/')[question.owner.link.split('/').length-1];
+                    }
                     return {
                         activity: {
                             description: `__${question.title}__\n\nTags: ${question.tags.join(', ')}`,
@@ -81,7 +87,7 @@ const prepare = (questions, type, options) => {
                         identity: {
                             source: 'Stack Overflow',
                             source_host: 'stackoverflow.com',
-                            username: question.owner.link.split('/')[question.owner.link.split('/').length-1],
+                            username: username,
                             url: question.owner.link,
                         }
                     }

--- a/tests/STACK_OVERFLOW_QUESTIONS.json
+++ b/tests/STACK_OVERFLOW_QUESTIONS.json
@@ -52,6 +52,28 @@
         "content_license": "CC BY-SA 4.0",
         "link": "https://stackoverflow.com/questions/67356446/wdio-get-length-of-items-list",
         "title": "Wdio - Get length of items list"
+      }, 
+      {
+        "tags": [ 
+          "javascript", 
+          "mongodb" 
+        ],
+        "owner": { 
+          "user_type": "does_not_exist", 
+          "display_name": "user17990806" 
+        },
+        "is_answered": false,
+        "view_count": 34,
+        "closed_date": 1647371400,
+        "answer_count": 1,
+        "score": 0,
+        "last_activity_date": 1647472554,
+        "creation_date": 1647246188,
+        "last_edit_date": 1647472554,
+        "question_id": 71464785,
+        "link": "https://stackoverflow.com/questions/71464785/error-serializing-meetups0-title-returned-from-getstaticprops-in",
+        "closed_reason": "Duplicate",
+        "title": "Error serializing `.meetups[0].title` returned from `getStaticProps` in &quot;/&quot;`"
       }
     ],
     "has_more": true,

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -83,6 +83,7 @@ describe('get questions', () => {
             expect(String(error).includes('tag')).toBeTruthy()
         }
     })
+
 })
 
 describe('prepare questions', () => {
@@ -103,6 +104,23 @@ describe('prepare questions', () => {
         expect(p.activity.activity_type).toBe('stackoverflow:question')
         expect(p.activity.title).toBeTruthy()
         expect(p.identity.source_host).toBe('stackoverflow.com')
+    }),
+
+    it('determines username value', async() => {
+        envVars(true)
+        const orbitStackOverflow = new OrbitStackOverflow()
+        const questions = await orbitStackOverflow.getQuestions({ tag: 'javascript', hours: 1 })
+        const prepared = await orbitStackOverflow.prepareQuestions(questions)
+        // registered user
+        const p0 = prepared[0]
+        expect(p0.identity.username).toBeTruthy()
+        expect(p0.identity.url).toBeDefined()
+        
+        // unregistered user
+        const p2 = prepared[2]
+        expect(p2.identity.username).toBeTruthy()
+        expect(p2.identity.url).toBeUndefined()
+
     })
 })
 


### PR DESCRIPTION
This is a PR for https://github.com/orbit-love/community-js-stackoverflow-orbit/issues/16

Essentially this update is to use `question.owner.display_name` value if `question.owner.link` is undefined. 
The link can be undefined when a user is not a registered user (do not have a user profile link) for example: https://stackoverflow.com/questions/71464785/error-serializing-meetups0-title-returned-from-getstaticprops-in

In this case, the display name would be `user<numbers>` this would also be equal to the username

